### PR TITLE
Fix version conflicts caused by PR#236

### DIFF
--- a/tests/SIO.Identity.Tests/SIO.Identity.Tests.csproj
+++ b/tests/SIO.Identity.Tests/SIO.Identity.Tests.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="OpenEventSourcing" Version="0.4.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore from 5.0.0 to 5.0.8. [(PR#236)](https://github.com/sound-it-out/sio-identity/pull/236).
Hope this fix can help you.

Best regards,
sucrose